### PR TITLE
use filename as alternative way to specify default address range

### DIFF
--- a/deadpool_dca.py
+++ b/deadpool_dca.py
@@ -440,7 +440,7 @@ class TracerGrind(Tracer):
         # Execution address range
         # Valgrind: reduce at least to 0x400000-0x3ffffff to avoid self-tracing
         if addr_range == 'default':
-            self.addr_range='0x400000-0x3ffffff'
+            self.addr_range='0x400000-0x3ffffff,' + os.path.realpath(target)
         if stack_range == 'default':
             if self.arch==ARCH.i386:
                 self.stack_range =(0xf0000000, 0xffffffff)


### PR DESCRIPTION
The hardcoded address range is not always correct. I think it doesn't hurt to try filtering with the
filename of the target as well, it might be more robust.