### PR TITLE
Fix: White Magic challenge link 

### DIFF
--- a/wbs_xxx_whitemagic/README.md
+++ b/wbs_xxx_whitemagic/README.md
@@ -2,7 +2,7 @@
 
 This challenge was made by Nahim (naam) El Atmani in 2016 in the context of the LSE CTF
 
-Ref: https://ctf.lse.epita.fr/ex/79/
+Ref: https://ctf.lse.re/challenges#White%20Magic-13
 
 Components
 ----------


### PR DESCRIPTION
Hello,

White Magic has been reup under a different link, here is the link to the new LSECTF.

Regards,

-- 
DaemonOnUnix